### PR TITLE
✅🔨 Update testmake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN echo $TZ > /etc/timezone && \
     ln --force --no-dereference --symbolic /usr/share/zoneinfo/$TZ /etc/localtime && \ 
     dpkg-reconfigure --frontend noninteractive tzdata
 RUN cd /tmp && \
-    git clone https://github.com/IslasGECI/misctools.git && \
-    cd misctools && \
+    git clone https://github.com/IslasGECI/testmake.git && \
+    cd testmake && \
     make install
 RUN mkdir --parents /workdir/IslasGECI && \
     mkdir --parents /workdir/data && \

--- a/README.md
+++ b/README.md
@@ -48,15 +48,16 @@ make --file=build/Makefile image
 ```
 
 5. Corre el contendor:
-  1. Si está corriendo el contenedor _reproducibility_inspector_ páralo y bórralo:
-```shell
-docker stop reproducibility_inspector
-docker rm reproducibility_inspector
-```
-  1. Corre el contenedor nuevo:
-```shell
-make --file=build/Makefile container
-```
+
+   1. Si está corriendo el contenedor _reproducibility_inspector_ páralo y bórralo:
+   ```shell
+   docker stop reproducibility_inspector
+   docker rm reproducibility_inspector
+   ```
+   2. Corre el contenedor nuevo:
+   ```shell
+   make --file=build/Makefile container
+   ```
 
 6. Corre las pruebas del contenedor huesped:
 ```shell

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ git clone https://github.com/IslasGECI/reproducibility_inspector.git
 3. Corre las pruebas del hospedero:
 ```shell
 cd reproducibility_inspector
-git fetch && git checkout origin/develop
+git checkout develop
+git pull
 make --file=build/Makefile tests
 ```
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -15,7 +15,7 @@ container:
 	docker run \
 		--detach \
 		--name reproducibility_inspector \
-		--restart always \
+		--rm \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
 		--volume ${HOME}/.testmake:${HOME}/.testmake \
 		--volume ${HOME}/.vault:${HOME}/.vault \

--- a/src/Cronfile
+++ b/src/Cronfile
@@ -2,5 +2,6 @@
 HOME=/home/ciencia_datos
 SHELL=/bin/bash
 USER=ciencia_datos
+UUID=a55d2311-89dd-4cf1-b5f3-74068147a259
 # Cron jobs
-0 18 * * * curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/a55d2311-89dd-4cf1-b5f3-74068147a259/start && source $HOME/.vault/.secrets && /workdir/src/get_repos.sh && /workdir/src/crawl_repos.sh && curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/a55d2311-89dd-4cf1-b5f3-74068147a259
+0 18 * * * . ${HOME}/src/notify_healthchecks.sh && notify_healthchecks "${UUID}/start" "Checking reproducibility" && source $HOME/.vault/.secrets && /workdir/src/get_repos.sh && /workdir/src/crawl_repos.sh && notify_healthchecks "${UUID}" "Reproducibility has been successfully checked" || notify_healthchecks "${UUID}/fail" "Reproducibility was not checked"

--- a/src/Cronfile
+++ b/src/Cronfile
@@ -4,4 +4,3 @@ SHELL=/bin/bash
 USER=ciencia_datos
 # Cron jobs
 0 16 * * * curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/a55d2311-89dd-4cf1-b5f3-74068147a259/start && source $HOME/.vault/.secrets && /workdir/src/get_repos.sh && /workdir/src/crawl_repos.sh && curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/a55d2311-89dd-4cf1-b5f3-74068147a259
-0 * * * * curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/4637ce28-50aa-41c8-93af-1489f5d7d296

--- a/src/Cronfile
+++ b/src/Cronfile
@@ -3,4 +3,4 @@ HOME=/home/ciencia_datos
 SHELL=/bin/bash
 USER=ciencia_datos
 # Cron jobs
-0 16 * * * curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/a55d2311-89dd-4cf1-b5f3-74068147a259/start && source $HOME/.vault/.secrets && /workdir/src/get_repos.sh && /workdir/src/crawl_repos.sh && curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/a55d2311-89dd-4cf1-b5f3-74068147a259
+0 18 * * * curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/a55d2311-89dd-4cf1-b5f3-74068147a259/start && source $HOME/.vault/.secrets && /workdir/src/get_repos.sh && /workdir/src/crawl_repos.sh && curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/a55d2311-89dd-4cf1-b5f3-74068147a259

--- a/src/notify_healthchecks.sh
+++ b/src/notify_healthchecks.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Notifica a Healthchecks.io
+
+function notify_healthchecks {
+  curl \
+    --data-raw "$2" \
+    --fail \
+    --max-time 10 \
+    --retry 5 \
+    --show-error \
+    --silent \
+    https://hc-ping.com/"$1"
+}


### PR DESCRIPTION
- [ ] Instala `geci-tesmake` a partir del nuevo repo `testmake` (en lugar de `misctools`).