### PR TITLE
🐛 Fix path

### DIFF
--- a/src/Cronfile
+++ b/src/Cronfile
@@ -4,4 +4,4 @@ SHELL=/bin/bash
 USER=ciencia_datos
 UUID=a55d2311-89dd-4cf1-b5f3-74068147a259
 # Cron jobs
-0 18 * * * . ${HOME}/src/notify_healthchecks.sh && notify_healthchecks "${UUID}/start" "Checking reproducibility" && source $HOME/.vault/.secrets && /workdir/src/get_repos.sh && /workdir/src/crawl_repos.sh && notify_healthchecks "${UUID}" "Reproducibility has been successfully checked" || notify_healthchecks "${UUID}/fail" "Reproducibility was not checked"
+0 18 * * * . /workdir/src/notify_healthchecks.sh && notify_healthchecks "${UUID}/start" "Checking reproducibility" && source $HOME/.vault/.secrets && /workdir/src/get_repos.sh && /workdir/src/crawl_repos.sh && notify_healthchecks "${UUID}" "Reproducibility has been successfully checked" || notify_healthchecks "${UUID}/fail" "Reproducibility was not checked"


### PR DESCRIPTION
Este hotfix es para corregir una ruta de un script que no permite la ejecución del inspector en nuestro servidor .dev

![image](https://user-images.githubusercontent.com/9456708/132049740-ca34c084-5f70-404b-9644-493f080526bd.png)